### PR TITLE
Adds pkg-config and zmq to requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ and fill out the following content:
 ```
 
 You can then run the following to compile and start the server:
-(Please Note: This requires `Go` being installed on your computer)
+(Please Note: This requires `Go`, `pkg-config` and `zmq` being installed on your computer)
 
 ```bash
 cd ./server


### PR DESCRIPTION
A new installation also requires pkg-config and zmq to successfully get the dependencies and build the server. Both are available through brew.